### PR TITLE
Support rspec 1 and 2

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,14 @@
 task :default => :spec
-require 'rspec/core/rake_task'
-RSpec::Core::RakeTask.new {|t| t.rspec_opts = ['--color']}
+
+# Support rspec 1 and 2
+begin
+  require 'rspec/core/rake_task'
+rescue LoadError
+  require 'spec/rake/spectask'
+  Spec::Rake::SpecTask.new {|t| t.spec_opts = ['--color']}
+else
+  RSpec::Core::RakeTask.new {|t| t.rspec_opts = ['--color']}
+end
 
 # rake install -> install gem locally (for tests)
 # rake release -> push to github and release to gemcutter


### PR DESCRIPTION
https://github.com/thuss/standalone-migrations/commit/a18087c66269e29010e8368242c05ae33c583533 changed rspec requirement from 1.x to 2.x. However rspec 1.x is still usable for running the tests.

Since standalone-migrations is frequently used in other projects as an infrastructure component, it would be nice if it imposed as few requirements as possible.

Please consider this patch which adds a fallback on rspec 1 if rspec 2 cannot be loaded.
