### PR TITLE
Added empty lines to readme to have code blocks correctly rendered on github

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -3,9 +3,11 @@ Rails migrations in non-Rails (and non Ruby) projects.
 USAGE
 =====
 Install Ruby, RubyGems and a ruby-database driver (e.g. `gem install mysql`) then:
+
     sudo gem install standalone_migrations
 
 Add to `Rakefile` in your projects base directory:
+
     begin
       require 'tasks/standalone_migrations'
       MigratorTasks.new do |t|
@@ -23,6 +25,7 @@ Add to `Rakefile` in your projects base directory:
     end
 
 Add database configuration to `db/config.yml` in your projects base directory e.g.:
+
     development:
       adapter: sqlite3
       database: db/development.sqlite3


### PR DESCRIPTION
It looks like an empty line is needed before code blocks. Compare:

https://github.com/thuss/standalone-migrations/blob/master/README.markdown
https://github.com/richmeyers/standalone-migrations/blob/readme-fix/README.markdown

This change adds three such empty lines.
