### PR TITLE
Patch for issue #10

### DIFF
--- a/lib/tasks/standalone_migrations.rb
+++ b/lib/tasks/standalone_migrations.rb
@@ -156,6 +156,7 @@ class MigratorTasks < ::Rake::TaskLib
     task :create do
       ar_init(false)
       config = ActiveRecord::Base.configurations[self.current_env]
+      raise ArgumentError, "#{self.current_env} database is not configured" unless config
       create_database config
     end
 

--- a/spec/standalone_migrations_spec.rb
+++ b/spec/standalone_migrations_spec.rb
@@ -105,6 +105,12 @@ end
     end
   end
 
+  describe 'db:create when nonexistent environment is specified' do
+    it "should provide an informative error message" do
+      run_with_output("rake db:create DB=nonexistent").should match /nonexistent database is not configured/
+    end
+  end
+
   describe 'db:new_migration' do
     context "single migration path" do
       it "fails if i do not add a name" do


### PR DESCRIPTION
Die with an informative error message when running db:create and specifying a nonexistent environment.

https://github.com/thuss/standalone-migrations/issues/10

I copied the wording from activerecord.
