### PR TITLE
Try a normal require of migration_helpers before using vendored copy

### DIFF
--- a/lib/tasks/standalone_migrations.rb
+++ b/lib/tasks/standalone_migrations.rb
@@ -72,7 +72,11 @@ class MigratorTasks < ::Rake::TaskLib
 
     desc "Migrate the database using the scripts in the migrations directory. Target specific version with VERSION=x. Turn off output with VERBOSE=false."
     task :migrate => :ar_init do
-      require "#{@vendor}/migration_helpers/init"
+      begin
+        require 'migration_helpers'
+      rescue LoadError
+        require "#{@vendor}/migration_helpers/init"
+      end
       ActiveRecord::Migration.verbose = ENV['VERBOSE'] || @verbose
       @migrations.each do |path|
         ActiveRecord::Migrator.migrate(path, ENV["VERSION"] ? ENV["VERSION"].to_i : nil)


### PR DESCRIPTION
This is the standalone_migrations part of changes for https://github.com/thuss/standalone-migrations/issues/17 . The migration_helpers part is at https://github.com/blaxter/migration_helpers/pull/1 .
