### PR TITLE
Fixing filename translation for new migrations. Fixes #31.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,4 @@
-Rails migrations in non-Rails (and non Ruby) projects.  
+Rails migrations in non-Rails (and non Ruby) projects.
 
 WHAT'S NEW
 ==========
@@ -70,7 +70,7 @@ The general form is:
     rake db:generate model="model_name" fields="type:column_name0 type:column_name1 ... type:column_namen"
 
 You can have as many fields as you would like.
-    
+
 An example to create a Person table with 3 columns (and it will automatically add the t.timestamps line)
 
     rake db:generate model="Person" fields="string:first_name string:last_name integer:age"
@@ -82,7 +82,7 @@ This will create a migration in db/migrate/
         create_table :Person do |t|
           t.string :first_name
           t.string :last_name
-          t.integer :age   
+          t.integer :age
           t.timestamps
         end
       end
@@ -108,14 +108,14 @@ This will create a migration in db/migrate/
 ### To execute a specific up/down of one single migration
 
     rake db:migrate:up VERSION=20081220234130
-    
+
 ### To revert your last migration
 
     rake db:rollback
 
 ### To revert your last 3 migrations
 
-    rake db:rollback STEP=3    
+    rake db:rollback STEP=3
 
 Contributors
 ============
@@ -127,5 +127,6 @@ Contributors
  - [Rich Meyers](https://github.com/richmeyers)
  - [Wes Bailey](http://exposinggotchas.blogspot.com/)
  - [Robert J. Berger](http://blog.ibd.com/)
+ - [Federico Builes](http://mheroin.com/)
 
 This work is originally based on [Lincoln Stoll's blog post](http://lstoll.net/2008/04/stand-alone-activerecord-migrations/) and [David Welton's post](http://journal.dedasys.com/2007/01/28/using-migrations-outside-of-rails).

--- a/lib/tasks/standalone_migrations.rb
+++ b/lib/tasks/standalone_migrations.rb
@@ -68,8 +68,9 @@ class #{class_name migration} < ActiveRecord::Migration
   end
 end
 eof
-    create_file file_name(migration), file_contents
-    puts "Created migration #{file_name migration}"
+    filename = migration.underscore
+    create_file file_name(filename), file_contents
+    puts "Created migration #{file_name filename}"
   end
 
   def create_file file, contents

--- a/spec/standalone_migrations_spec.rb
+++ b/spec/standalone_migrations_spec.rb
@@ -110,6 +110,11 @@ test:
       run("rake db:new_migration name=test_abc").should =~ %r{Created migration db/migrate/\d+_test_abc\.rb}
       run("ls db/migrate").should =~ /^\d+_test_abc.rb$/
     end
+
+    it "generates a new migration with the name converted to the Rails migration format" do
+      run("rake db:new_migration name=MyNiceModel").should =~ %r{Created migration db/migrate/\d+_my_nice_model\.rb}
+      run("ls db/migrate").should =~ /^\d+_my_nice_model.rb$/
+    end
   end
 
   describe 'db:version' do
@@ -169,30 +174,30 @@ test:
       lambda{ run("rake db:migrate:up") }.should raise_error(/VERSION/)
     end
   end
-  
+
   describe 'db:rollback' do
     it "does nothing when no migrations have been run" do
       run("rake db:version").should =~ /version: 0/
       run("rake db:rollback").should == ''
-      run("rake db:version").should =~ /version: 0/      
+      run("rake db:version").should =~ /version: 0/
     end
-    
-    it "rolls back the last migration if one has been applied" do     
-      write_multiple_migrations      
-      run("rake db:migrate")      
+
+    it "rolls back the last migration if one has been applied" do
+      write_multiple_migrations
+      run("rake db:migrate")
       run("rake db:version").should =~ /version: 20100509095816/
       run("rake db:rollback").should =~ /revert/
       run("rake db:version").should =~ /version: 20100509095815/
     end
-    
+
     it "rolls back multiple migrations if the STEP argument is given" do
-      write_multiple_migrations      
-      run("rake db:migrate")      
+      write_multiple_migrations
+      run("rake db:migrate")
       run("rake db:version").should =~ /version: 20100509095816/
       run("rake db:rollback STEP=2") =~ /revert/
       run("rake db:version").should =~ /version: 0/
     end
-  end  
+  end
 
   describe 'schema:dump' do
     it "dumps the schema" do
@@ -248,7 +253,7 @@ test:
       run('rake db:test:purge')
     end
   end
-  
+
   describe 'db:migrate when environment is specified' do
     it "runs when using the DB environment variable" do
       make_migration('yyy')
@@ -256,9 +261,9 @@ test:
       run('rake db:version DB=test').should_not =~ /version: 0/
       run('rake db:version').should =~ /version: 0/
     end
-    
+
     it "should error on an invalid database" do
       lambda{ run("rake db:create DB=nonexistent")}.should raise_error(/rake aborted/)
-    end    
+    end
   end
 end


### PR DESCRIPTION
- When you run create a migration like: `rake db:new_migration name=FooBarBaz` the resulting
  filename should be `[date]_foo_bar_baz_migration.rb`, not `[date]_FooBarBaz_migration.rb`
