### PR TITLE
Adding support for `rake db:reset`. Fixes #32.

### DIFF
--- a/lib/tasks/standalone_migrations.rb
+++ b/lib/tasks/standalone_migrations.rb
@@ -36,6 +36,8 @@ module Rails
       end
       s
     end
+
+    def s.load_seed; end        # no-op, needed for db:reset
     s
   end
 end


### PR DESCRIPTION
- Since this functionality is mostly provided by ActiveRecord I don't know if we should be spec'ing out the behavior. Feel free to modify this if you deem it necessary.
