### PR TITLE
Re: Setting schema in .standalone_migrations does not work

### DIFF
--- a/lib/standalone_migrations/configurator.rb
+++ b/lib/standalone_migrations/configurator.rb
@@ -36,6 +36,7 @@ module StandaloneMigrations
         :schema       => "db/schema.rb"
       }
       @options = load_from_file(defaults.dup) || defaults.merge(options)
+      ENV['SCHEMA'] = schema
     end
 
     def config


### PR DESCRIPTION
This fixes issue #41
