### PR TITLE
Update README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -50,7 +50,7 @@ Add database configuration to `db/config.yml` in your projects base directory e.
 
 ### To create a new database migration:
 
-    rake db:new_migration name=FooBarMigration
+    rake db:new_migration name=foo_bar_migration
     edit db/migrate/20081220234130_foo_bar_migration.rb
 
 #### If you really want to, you can just execute raw SQL:


### PR DESCRIPTION
When generating a new migration it should be underscore case instead of camel case. As camelcase does not generate the correct class name.

`rake db:new_migration name=foo_bar_migration`

instead of

`rake db:new_migration name=FooBarMigration`
