### PR TITLE
expand_path for schema to solve issue with db:schema:load

### DIFF
--- a/lib/standalone_migrations/configurator.rb
+++ b/lib/standalone_migrations/configurator.rb
@@ -36,7 +36,7 @@ module StandaloneMigrations
         :schema       => "db/schema.rb"
       }
       @options = load_from_file(defaults.dup) || defaults.merge(options)
-      ENV['SCHEMA'] = schema
+      ENV['SCHEMA'] = File.expand_path(schema)
     end
 
     def config


### PR DESCRIPTION
I'm using ruby with rbenv, and i'm not sure if that's the cause, but this is the solution to the schema not being load.

> #### load(filename, wrap=false) → true
> 
> Loads and executes the Ruby program in the file filename. If the filename does not resolve to an absolute path, the file is searched for in the library directories listed in $:. If the optional wrap parameter is true, the loaded script will be executed under an anonymous module, protecting the calling program’s global namespace. In no circumstance will any local variables in the loaded file be propagated to the loading environment.
