### PR TITLE
Updating gem dependencies to latest: 3.2.11

### DIFF
--- a/standalone_migrations.gemspec
+++ b/standalone_migrations.gemspec
@@ -53,17 +53,17 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<rake>, [">= 0"])
-      s.add_runtime_dependency(%q<activerecord>, ["~> 3.2.6"])
-      s.add_runtime_dependency(%q<railties>, ["~> 3.2.6"])
+      s.add_runtime_dependency(%q<activerecord>, ["~> 3.2.11"])
+      s.add_runtime_dependency(%q<railties>, ["~> 3.2.11"])
     else
       s.add_dependency(%q<rake>, [">= 0"])
-      s.add_dependency(%q<activerecord>, ["~> 3.2.6"])
-      s.add_dependency(%q<railties>, ["~> 3.2.6"])
+      s.add_dependency(%q<activerecord>, ["~> 3.2.11"])
+      s.add_dependency(%q<railties>, ["~> 3.2.11"])
     end
   else
     s.add_dependency(%q<rake>, [">= 0"])
-    s.add_dependency(%q<activerecord>, ["~> 3.2.6"])
-    s.add_dependency(%q<railties>, ["~> 3.2.6"])
+    s.add_dependency(%q<activerecord>, ["~> 3.2.11"])
+    s.add_dependency(%q<railties>, ["~> 3.2.11"])
   end
 end
 


### PR DESCRIPTION
There are weird conflicts when I use 3.2.6 and 3.2.11 in a project (naturally). There's no real reason to leave the dependencies for this gem lower than current unless it breaks stuff. Seems to be fine here.
