### PR TITLE
Allow ruby code in config files

### DIFF
--- a/lib/standalone_migrations/configurator.rb
+++ b/lib/standalone_migrations/configurator.rb
@@ -75,7 +75,7 @@ module StandaloneMigrations
 
     def load_from_file(defaults)
       return nil unless File.exists? configuration_file
-      config = YAML.load( IO.read(configuration_file) ) 
+      config = YAML.load( ERB.new(IO.read(configuration_file)).result )
       {
         :config       => config["config"] ? config["config"]["database"] : defaults[:config],
         :migrate_dir  => config["db"] ? config["db"]["migrate"] : defaults[:migrate_dir],

--- a/spec/standalone_migrations_spec.rb
+++ b/spec/standalone_migrations_spec.rb
@@ -81,7 +81,7 @@ end
     write_rakefile
     write 'db/config.yml', <<-TXT
 development:
-  adapter: sqlite3
+  adapter: <%= "sqlite3" %>
   database: db/development.sql
 test:
   adapter: sqlite3


### PR DESCRIPTION
For example:

``` yml
db:
  schema: <%= ENV['SCHEMA'] %>
```
