### PR TITLE
Fix a bug where config.yml is required

### DIFF
--- a/lib/standalone_migrations/configurator.rb
+++ b/lib/standalone_migrations/configurator.rb
@@ -1,9 +1,11 @@
 require 'active_support/all'
+require 'yaml'
 
 module StandaloneMigrations
 
   class InternalConfigurationsProxy
 
+    attr_reader :configurations
     def initialize(configurations)
       @configurations = configurations
     end

--- a/lib/standalone_migrations/tasks.rb
+++ b/lib/standalone_migrations/tasks.rb
@@ -12,7 +12,9 @@ module StandaloneMigrations
 
       def load_tasks
         configure
-
+        Configurator.environments_config do |proxy|
+          ActiveRecord::Tasks::DatabaseTasks.database_configuration = proxy.configurations
+        end
         MinimalRailtieConfig.load_tasks
         %w(
           connection

--- a/spec/standalone_migrations_spec.rb
+++ b/spec/standalone_migrations_spec.rb
@@ -44,7 +44,6 @@ describe 'Standalone migrations' do
 $LOAD_PATH.unshift '#{File.expand_path('lib')}'
 begin
   require "standalone_migrations"
-  ActiveRecord::Tasks::DatabaseTasks.database_configuration = YAML.load_file('db/config.yml')
   StandaloneMigrations::Tasks.load_tasks
 rescue LoadError => e
   puts "gem install standalone_migrations to get db:migrate:* tasks! (Error: \#{e})"


### PR DESCRIPTION
### Purpose

This is a fix for issue #109.

Basically we have to setup database configuration of AR when loading tasks. The reason for the tests passed previously was because the configuration was setup manually in the tests themselves