### PR TITLE
Properly support DATABASE_URL

### DIFF
--- a/lib/standalone_migrations/tasks/connection.rake
+++ b/lib/standalone_migrations/tasks/connection.rake
@@ -1,8 +1,8 @@
 require File.expand_path("../../../standalone_migrations", __FILE__)
 namespace :standalone do
   task :connection do
-    configurator = StandaloneMigrations::Configurator.new
-    ActiveRecord::Base.establish_connection configurator.config_for(Rails.env)
+    StandaloneMigrations::Configurator.load_configurations
+    ActiveRecord::Base.establish_connection
     StandaloneMigrations.run_on_load_callbacks
   end
 end

--- a/spec/standalone_migrations/configurator_spec.rb
+++ b/spec/standalone_migrations/configurator_spec.rb
@@ -39,7 +39,7 @@ module StandaloneMigrations
 
       it "load the yaml with environment configurations" do
         config = Configurator.new.config_for(:development)
-        config[:database].should == "db/development.sql"
+        config["database"].should == "db/development.sql"
       end
 
       it "allow access the original configuration hash (for all environments)" do


### PR DESCRIPTION
Switched out the code for loading configuration for Rails's version of
loading database configuration.

Rails has implemented support for DATABASE_URL in rails/rails#13463 and
has dealt with the possible combinations of having DATABASE_URL set and
a YAML config file, see https://github.com/rails/rails/pull/13463#issuecomment-31480799.

There is a breaking change in the way the hash is loaded; Rails does not
convert the keys of the hash to symbols, instead they are left as
strings; any code reliant on the hash keys being symbols will break.