### PR TITLE
make non-default seeds.rb work

### DIFF
--- a/lib/standalone_migrations/configurator.rb
+++ b/lib/standalone_migrations/configurator.rb
@@ -21,7 +21,7 @@ module StandaloneMigrations
 
   class Configurator
     def self.load_configurations
-      @standalone_configs ||= Configurator.new.config
+      self.new
       @env_config ||= Rails.application.config.database_configuration
       ActiveRecord::Base.configurations = @env_config
       @env_config

--- a/lib/standalone_migrations/tasks.rb
+++ b/lib/standalone_migrations/tasks.rb
@@ -7,7 +7,7 @@ module StandaloneMigrations
         paths = Rails.application.config.paths
         paths.add "config/database", :with => configurator.config
         paths.add "db/migrate", :with => configurator.migrate_dir
-        paths.add "db/seeds", :with => configurator.seeds
+        paths.add "db/seeds.rb", :with => configurator.seeds
       end
 
       def load_tasks

--- a/spec/standalone_migrations_spec.rb
+++ b/spec/standalone_migrations_spec.rb
@@ -303,6 +303,27 @@ test:
       run("rake db:seed").should =~ /LOADEDDD/
     end
 
+    describe 'with non-default seed file' do
+      let(:yaml_hash) do
+        {
+          "db" => {
+            "seeds" => "db/seeds2.rb",
+          }
+        }
+      end
+
+      before do
+        write(".standalone_migrations", yaml_hash.to_yaml)
+      end
+
+
+      it "loads" do
+        write("db/seeds2.rb", "puts 'LOADEDDD'")
+        run("rake db:seed").should =~ /LOADEDDD/
+      end
+    end
+
+
     it "does nothing without seeds" do
       run("rake db:seed").length.should == 0
     end


### PR DESCRIPTION
Rails config uses `db/seeds.rb` to hold the seeds file path, not `db/seeds`: https://github.com/rails/rails/blob/master/railties/lib/rails/engine.rb#L548.