### PR TITLE
Fixed README because `DB` environment does not work

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -72,7 +72,6 @@ end
 
 ### To migrate a specific database (for example your "testing" database)
 
-    rake db:migrate DB=test ... or ...
     rake db:migrate RAILS_ENV=test
 
 ### To execute a specific up/down of one single migration
@@ -163,11 +162,11 @@ Of course you can achieve a different layout by simply editing the paths.
 
 You can run the Rake tasks on a particular database by passing the `DATABASE` environment variable to it:
 
-    $ rake DATABASE=db1 db:version
+    $ rake db:version DATABASE=db1
 
 Combined with the environment selector:
 
-    $ rake DATABASE=db2 DB=production db:migrate
+    $ rake db:migrate DATABASE=db2 RAILS_ENV=production
 
 #### Changing environment config in runtime
 


### PR DESCRIPTION
Hi, I found that `DB` environment does not work. But `RAILS_ENV` environment is ok. So I fixed README.

# Trace

* Ruby 2.2.3
* standalone_migrations 4.0.3

```sh
# For single database
$ bundle exec rake db:migrate DB=test
rake aborted!
ActiveRecord::AdapterNotSpecified: 'development' database is not configured. Available: ["test"]

# For multiple databases
$ bundle exec rake db:migrate DATABASE=sample2 DB=test
rake aborted!
ActiveRecord::AdapterNotSpecified: 'development' database is not configured. Available: ["test"]
```

# Workaround

I think that `RAILS_ENV` in `ActiveRecord::ConnectionHandling` return `development` forcibly.

* https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_handling.rb

So this is workaround to use `DB` environment.

```diff
if !ENV["RAILS_ENV"]
  ENV["RAILS_ENV"] = ENV["DB"] || ENV["RACK_ENV"] || Rails.env || "development"
+ Rails.env = ENV["RAILS_ENV"]
end
```

@thuss 
Please review, thank you! 😃 