### PR TITLE
stop keeping rake at 10.x

### DIFF
--- a/standalone_migrations.gemspec
+++ b/standalone_migrations.gemspec
@@ -59,11 +59,11 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<rake>, ["~> 10.0"])
+      s.add_runtime_dependency(%q<rake>, [">= 10.0"])
       s.add_runtime_dependency(%q<activerecord>, ["< 5.2.0", ">= 4.2.7"])
       s.add_runtime_dependency(%q<railties>, ["< 5.2.0", ">= 4.2.7"])
     else
-      s.add_dependency(%q<rake>, ["~> 10.0"])
+      s.add_dependency(%q<rake>, [">= 10.0"])
       s.add_dependency(%q<activerecord>, ["< 5.2.0", ">= 4.2.7"])
       s.add_dependency(%q<railties>, ["< 5.2.0", ">= 4.2.7"])
     end


### PR DESCRIPTION
In any project that uses this as a dependency, can't use any
rake past 10.x, like 11.x or 12.x.

Really, I'm not sure _any_ of these dependencies should be runtime
rather than development dependencies. But I'm not sure about that, I'll
leave it alone. But please stop forcing no rake newer than 10.x.