### PR TITLE
StandaloneMigrations::Configurator: Default schema file name to whatever ActiveRecord defaults to

### DIFF
--- a/lib/standalone_migrations/configurator.rb
+++ b/lib/standalone_migrations/configurator.rb
@@ -33,14 +33,14 @@ module StandaloneMigrations
     end
 
     def initialize(options = {})
+      default_schema = ENV['SCHEMA'] || ActiveRecord::Tasks::DatabaseTasks.schema_file(ActiveRecord::Base.schema_format)
       defaults = {
         :config       => "db/config.yml",
         :migrate_dir  => "db/migrate",
         :seeds        => "db/seeds.rb",
-        :schema       => "db/schema.rb"
+        :schema       => default_schema
       }
       @options = load_from_file(defaults.dup) || defaults.merge(options)
-      ENV['SCHEMA'] = ENV['SCHEMA'] || File.expand_path(schema)
 
       Rails.application.config.root = Pathname.pwd
       Rails.application.config.paths["config/database"] = config

--- a/spec/standalone_migrations/configurator_spec.rb
+++ b/spec/standalone_migrations/configurator_spec.rb
@@ -105,7 +105,7 @@ module StandaloneMigrations
       end
 
       it "use db/schema.rb" do
-        expect(configurator.schema).to eq("db/schema.rb")
+        expect(configurator.schema).to end_with("/db/schema.rb")
       end
 
     end


### PR DESCRIPTION
This allows ActiveRecord to choose between `schema.rb` and `structure.sql` as the file name, and setting `ActiveRecord::Base.schema_format = :sql` will actually dump to the right file (`structure.sql`).

This should address <https://github.com/thuss/standalone-migrations/issues/129>.

(The spec needed to be adjusted because `ActiveRecord::Tasks::DatabaseTasks.schema_file` returns an absolute path, not a relative path.)