### PR TITLE
allow and test rails 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,5 @@ env:
   - AR="~> 4.2.0" NOKOGIRI_USE_SYSTEM_LIBRARIES=1
   - AR="~> 5.0.0" NOKOGIRI_USE_SYSTEM_LIBRARIES=1
   - AR=">= 5.1.0.rc2,< 5.2" NOKOGIRI_USE_SYSTEM_LIBRARIES=1
+  - AR=">= 5.2.0.rc2,< 5.3" NOKOGIRI_USE_SYSTEM_LIBRARIES=1
 script: bundle exec rake specs:travis

--- a/standalone_migrations.gemspec
+++ b/standalone_migrations.gemspec
@@ -59,17 +59,17 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<rake>, [">= 10.0"])
-      s.add_runtime_dependency(%q<activerecord>, ["< 5.2.0", ">= 4.2.7"])
-      s.add_runtime_dependency(%q<railties>, ["< 5.2.0", ">= 4.2.7"])
+      s.add_runtime_dependency(%q<activerecord>, ["< 5.3.0", ">= 4.2.7"])
+      s.add_runtime_dependency(%q<railties>, ["< 5.3.0", ">= 4.2.7"])
     else
       s.add_dependency(%q<rake>, [">= 10.0"])
-      s.add_dependency(%q<activerecord>, ["< 5.2.0", ">= 4.2.7"])
-      s.add_dependency(%q<railties>, ["< 5.2.0", ">= 4.2.7"])
+      s.add_dependency(%q<activerecord>, ["< 5.3.0", ">= 4.2.7"])
+      s.add_dependency(%q<railties>, ["< 5.3.0", ">= 4.2.7"])
     end
   else
     s.add_dependency(%q<rake>, [">= 10.0"])
-    s.add_dependency(%q<activerecord>, ["< 5.2.0", ">= 4.2.7"])
-    s.add_dependency(%q<railties>, ["< 5.2.0", ">= 4.2.7"])
+    s.add_dependency(%q<activerecord>, ["< 5.3.0", ">= 4.2.7"])
+    s.add_dependency(%q<railties>, ["< 5.3.0", ">= 4.2.7"])
   end
 end
 


### PR DESCRIPTION
No changes needed, all tests pass. Just changed gemspec to allow 5.2, and .travis to test it. 

I use standalone_migrations in spec for a gem I need to start testing under rails 5.2, so I can find any problems before rails 5.2 comes out, perhaps reporting them upstream to rails if needed, like a good citizen before rails 5.2.0 comes out.

Note that as a result of my [previous PR to allow Rails 5.1](https://github.com/thuss/standalone-migrations/commit/c264457ead4dfdd06f55d6d5d5195bb7a31c3abd#diff-354f30a63fb0907d4ad57269548329e3), travis was already testing _multiple times_, for each rails version. After this PR, for 4.2, 5.0, 5.1, and 5.2.  So even adding in Rails 5.2 support here, travis is still testing under all previously supported Rails minor versions -- it's still testing under 5.1 too, for instance. 

Closes #140 