### PR TITLE
gem install mysql2

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -12,7 +12,7 @@ CONTRIBUTE
 
 USAGE
 =====
-Install Ruby, RubyGems and a ruby-database driver (e.g. `gem install mysql`) then:
+Install Ruby, RubyGems and a ruby-database driver (e.g. `gem install mysql` or `gem install mysql2`) then:
 
     $ gem install standalone_migrations
 


### PR DESCRIPTION
### What does this PR do?

`gem install mysql` -> no longer works. Tested in Mac.

However `gem install mysql2` -> works well.

My MySQL version is 5.7 >

Reference: https://stackoverflow.com/questions/9609985/please-install-mysql-adapter-gem-install-activerecord-mysql-adapter