### PR TITLE
Add schema path to ENV[schema] to change defualt path

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'activerecord', ENV['AR'] ? ENV['AR'].split(",") : [">= 4.2.7", "< 5.3.0"]
 gem 'railties', ENV['AR'] ? ENV['AR'].split(",") : [">= 4.2.7", "< 5.3.0"]
 
 group :dev do
-  gem 'sqlite3'
+  gem 'sqlite3', '~> 1.3.6'
   gem 'rspec', '>= 2.99.0'
   gem 'jeweler'
 end

--- a/lib/standalone_migrations/configurator.rb
+++ b/lib/standalone_migrations/configurator.rb
@@ -42,6 +42,7 @@ module StandaloneMigrations
       }
       @options = load_from_file(defaults.dup) || defaults.merge(options)
 
+      ENV['SCHEMA'] = schema
       Rails.application.config.root = root
       Rails.application.config.paths["config/database"] = config
       Rails.application.config.paths["db/migrate"] = migrate_dir

--- a/lib/standalone_migrations/generator.rb
+++ b/lib/standalone_migrations/generator.rb
@@ -1,11 +1,22 @@
 # these generators are backed by rails' generators
 require "rails/generators"
+require 'rails/generators/active_record/migration/migration_generator'
 module StandaloneMigrations
   class Generator
     def self.migration(name, options="")
       generator_params = [name] + options.split(" ")
       Rails::Generators.invoke "active_record:migration", generator_params,
         :destination_root => Rails.root
+    end
+  end
+
+  class CacheMigrationGenerator < ActiveRecord::Generators::MigrationGenerator
+    source_root File.join(File.dirname(ActiveRecord::Generators::MigrationGenerator.instance_method(:create_migration_file).source_location.first), "templates")
+
+    def create_migration_file
+      set_local_assigns!
+      validate_file_name!
+      migration_template @migration_template, Rails.application.config.paths["db/migrate"]
     end
   end
 end


### PR DESCRIPTION
**Bug** 
whenever you try to run `rake db:migrate` with multiple database connections will only generate a single schema file at `db/schema.rb`

**Cause**
we don't set the `ENV['SCHEMA']` path, so it will always be the default schema, which is `db/schema.rb`

**Solution** 
Add schema new path to ENV['SCHEMA'] when configuring the connection
Update old test cases to accept dynamic schema