### PR TITLE
move environment config into connection task

### DIFF
--- a/lib/standalone_migrations/tasks.rb
+++ b/lib/standalone_migrations/tasks.rb
@@ -8,9 +8,7 @@ module StandaloneMigrations
 
       def load_tasks(options = {})
         configure(options)
-        Configurator.environments_config do |proxy|
-          ActiveRecord::Tasks::DatabaseTasks.database_configuration = proxy.configurations
-        end
+
         MinimalRailtieConfig.load_tasks
         %w(
           connection

--- a/lib/standalone_migrations/tasks/connection.rake
+++ b/lib/standalone_migrations/tasks/connection.rake
@@ -1,6 +1,9 @@
 require File.expand_path("../../../standalone_migrations", __FILE__)
 namespace :standalone do
   task :connection do
+    StandaloneMigrations::Configurator.environments_config do |proxy|
+      ActiveRecord::Tasks::DatabaseTasks.database_configuration = proxy.configurations
+    end
     StandaloneMigrations::Configurator.load_configurations
     ActiveRecord::Base.establish_connection
     StandaloneMigrations.run_on_load_callbacks


### PR DESCRIPTION
move environment configuration into connection task, so it's not executed in situations where no standalone-migrations task is called. Allows other rake tasks to be executed when db/config.yml is missing. 
fixes #152 