### PR TITLE
ActiveRecord 6.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
 gem 'rake', '>= 10.0'
-gem 'activerecord', ENV['AR'] ? ENV['AR'].split(",") : [">= 4.2.7", "< 6.1.0", "!= 5.2.3", "!=5.2.3.rc1"]
-gem 'railties', ENV['AR'] ? ENV['AR'].split(",") : [">= 4.2.7", "< 6.1.0", "!= 5.2.3", "!=5.2.3.rc1"]
+gem 'activerecord', ENV['AR'] ? ENV['AR'].split(",") : [">= 4.2.7", "<= 6.1.0", "!= 5.2.3", "!=5.2.3.rc1"]
+gem 'railties', ENV['AR'] ? ENV['AR'].split(",") : [">= 4.2.7", "<= 6.1.0", "!= 5.2.3", "!=5.2.3.rc1"]
 
 group :dev do
   gem 'sqlite3', ENV['SQL'] ? ENV['SQL'].split(",") : ['~> 1.4']

--- a/standalone_migrations.gemspec
+++ b/standalone_migrations.gemspec
@@ -60,12 +60,12 @@ Gem::Specification.new do |s|
 
   if s.respond_to? :add_runtime_dependency then
     s.add_runtime_dependency(%q<rake>.freeze, [">= 10.0"])
-    s.add_runtime_dependency(%q<activerecord>.freeze, [">= 4.2.7", "< 6.1.0", "!= 5.2.3", "!= 5.2.3.rc1"])
-    s.add_runtime_dependency(%q<railties>.freeze, [">= 4.2.7", "< 6.1.0", "!= 5.2.3", "!= 5.2.3.rc1"])
+    s.add_runtime_dependency(%q<activerecord>.freeze, [">= 4.2.7", "<= 6.1.0", "!= 5.2.3", "!= 5.2.3.rc1"])
+    s.add_runtime_dependency(%q<railties>.freeze, [">= 4.2.7", "<= 6.1.0", "!= 5.2.3", "!= 5.2.3.rc1"])
   else
     s.add_dependency(%q<rake>.freeze, [">= 10.0"])
-    s.add_dependency(%q<activerecord>.freeze, [">= 4.2.7", "< 6.1.0", "!= 5.2.3", "!= 5.2.3.rc1"])
-    s.add_dependency(%q<railties>.freeze, [">= 4.2.7", "< 6.1.0", "!= 5.2.3", "!= 5.2.3.rc1"])
+    s.add_dependency(%q<activerecord>.freeze, [">= 4.2.7", "<= 6.1.0", "!= 5.2.3", "!= 5.2.3.rc1"])
+    s.add_dependency(%q<railties>.freeze, [">= 4.2.7", "<= 6.1.0", "!= 5.2.3", "!= 5.2.3.rc1"])
   end
 end
 


### PR DESCRIPTION
I don't see why AR and Railties should be limited to `< 6.1`.