### PR TITLE
Add support for Rails 6.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,10 @@ jobs:
       env: AR="~> 4.2.0" SQL="~>1.3.6" NOKOGIRI_USE_SYSTEM_LIBRARIES=1
     - rvm: 2.7.3
       env: AR="~> 4.2.0" SQL="~>1.3.6" NOKOGIRI_USE_SYSTEM_LIBRARIES=1
+    - rvm: 2.7.3
+      env: AR="~> 5.0.0" SQL="~>1.3.6" NOKOGIRI_USE_SYSTEM_LIBRARIES=1
+    - rvm: 2.7.3
+      env: AR=">= 5.1.0.rc2,< 5.2" SQL="~>1.3.6" NOKOGIRI_USE_SYSTEM_LIBRARIES=1
+    - rvm: 2.7.3
+      env: AR=">= 5.2.0.rc2,< 5.3,!= 5.2.3,!=5.2.3.rc1" SQL="~>1.3.6" NOKOGIRI_USE_SYSTEM_LIBRARIES=1
 script: bundle exec rake specs:travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,14 @@ language: ruby
 rvm:
   - 2.5.7
   - 2.6.5
+  - 2.7.3
 env:
   - AR="~> 4.2.0" SQL="~>1.3.6" NOKOGIRI_USE_SYSTEM_LIBRARIES=1
   - AR="~> 5.0.0" SQL="~>1.3.6" NOKOGIRI_USE_SYSTEM_LIBRARIES=1
   - AR=">= 5.1.0.rc2,< 5.2" SQL="~>1.3.6" NOKOGIRI_USE_SYSTEM_LIBRARIES=1
   - AR=">= 5.2.0.rc2,< 5.3,!= 5.2.3,!=5.2.3.rc1" SQL="~>1.3.6" NOKOGIRI_USE_SYSTEM_LIBRARIES=1
   - AR="~> 6.0.0" SQL="~>1.4" NOKOGIRI_USE_SYSTEM_LIBRARIES=1
+  - AR="~> 6.1.0" SQL="~>1.4" NOKOGIRI_USE_SYSTEM_LIBRARIES=1
 jobs:
   exclude:
     - rvm: 2.6.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,6 @@ jobs:
   exclude:
     - rvm: 2.6.5
       env: AR="~> 4.2.0" SQL="~>1.3.6" NOKOGIRI_USE_SYSTEM_LIBRARIES=1
+    - rvm: 2.7.3
+      env: AR="~> 4.2.0" SQL="~>1.3.6" NOKOGIRI_USE_SYSTEM_LIBRARIES=1
 script: bundle exec rake specs:travis

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
 gem 'rake', '>= 10.0'
-gem 'activerecord', ENV['AR'] ? ENV['AR'].split(",") : [">= 4.2.7", "< 6.1.0", "!= 5.2.3", "!=5.2.3.rc1"]
-gem 'railties', ENV['AR'] ? ENV['AR'].split(",") : [">= 4.2.7", "< 6.1.0", "!= 5.2.3", "!=5.2.3.rc1"]
+gem 'activerecord', ENV['AR'] ? ENV['AR'].split(",") : [">= 4.2.7", "< 6.2.0", "!= 5.2.3", "!=5.2.3.rc1"]
+gem 'railties', ENV['AR'] ? ENV['AR'].split(",") : [">= 4.2.7", "< 6.2.0", "!= 5.2.3", "!=5.2.3.rc1"]
 
 group :dev do
   gem 'sqlite3', ENV['SQL'] ? ENV['SQL'].split(",") : ['~> 1.4']

--- a/README.markdown
+++ b/README.markdown
@@ -269,3 +269,4 @@ Contributors
  - [Benjamin Dobell](https://github.com/Benjamin-Dobell)
  - [Hassan Mahmoud](https://github.com/HassanTC)
  - [Marco Adkins](https://github.com/marcoadkins)
+ - [Mithun James](https://github.com/drtechie)

--- a/standalone_migrations.gemspec
+++ b/standalone_migrations.gemspec
@@ -60,12 +60,12 @@ Gem::Specification.new do |s|
 
   if s.respond_to? :add_runtime_dependency then
     s.add_runtime_dependency(%q<rake>.freeze, [">= 10.0"])
-    s.add_runtime_dependency(%q<activerecord>.freeze, [">= 4.2.7", "< 6.1.0", "!= 5.2.3", "!= 5.2.3.rc1"])
-    s.add_runtime_dependency(%q<railties>.freeze, [">= 4.2.7", "< 6.1.0", "!= 5.2.3", "!= 5.2.3.rc1"])
+    s.add_runtime_dependency(%q<activerecord>.freeze, [">= 4.2.7", "< 6.2.0", "!= 5.2.3", "!= 5.2.3.rc1"])
+    s.add_runtime_dependency(%q<railties>.freeze, [">= 4.2.7", "< 6.2.0", "!= 5.2.3", "!= 5.2.3.rc1"])
   else
     s.add_dependency(%q<rake>.freeze, [">= 10.0"])
-    s.add_dependency(%q<activerecord>.freeze, [">= 4.2.7", "< 6.1.0", "!= 5.2.3", "!= 5.2.3.rc1"])
-    s.add_dependency(%q<railties>.freeze, [">= 4.2.7", "< 6.1.0", "!= 5.2.3", "!= 5.2.3.rc1"])
+    s.add_dependency(%q<activerecord>.freeze, [">= 4.2.7", "< 6.2.0", "!= 5.2.3", "!= 5.2.3.rc1"])
+    s.add_dependency(%q<railties>.freeze, [">= 4.2.7", "< 6.2.0", "!= 5.2.3", "!= 5.2.3.rc1"])
   end
 end
 


### PR DESCRIPTION
Changes made

 - Changed AR dependency to < 6.2.0
 - Added necessary changes in travis.yml
   - Added Ruby version 2.7.3
   - Excluded AR <= 5.2 from 2.7.3 tests.

Addresses: #165 