### PR TITLE
Add specs for ActiveRecord 7.0 and Ruby 3.0 + update ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: ruby
 rvm:
-  - 2.5.7
-  - 2.6.5
-  - 2.7.3
+  - 2.5.9
+  - 2.6.9
+  - 2.7.5
+  - 3.0.3
 env:
   - AR="~> 4.2.0" SQL="~>1.3.6" NOKOGIRI_USE_SYSTEM_LIBRARIES=1
   - AR="~> 5.0.0" SQL="~>1.3.6" NOKOGIRI_USE_SYSTEM_LIBRARIES=1
@@ -10,16 +11,19 @@ env:
   - AR=">= 5.2.0.rc2,< 5.3,!= 5.2.3,!=5.2.3.rc1" SQL="~>1.3.6" NOKOGIRI_USE_SYSTEM_LIBRARIES=1
   - AR="~> 6.0.0" SQL="~>1.4" NOKOGIRI_USE_SYSTEM_LIBRARIES=1
   - AR="~> 6.1.0" SQL="~>1.4" NOKOGIRI_USE_SYSTEM_LIBRARIES=1
+  - AR="~> 7.0.0" SQL="~>1.4" NOKOGIRI_USE_SYSTEM_LIBRARIES=1
 jobs:
   exclude:
-    - rvm: 2.6.5
+    - rvm: 2.6.9
       env: AR="~> 4.2.0" SQL="~>1.3.6" NOKOGIRI_USE_SYSTEM_LIBRARIES=1
-    - rvm: 2.7.3
+    - rvm: 2.7.5
       env: AR="~> 4.2.0" SQL="~>1.3.6" NOKOGIRI_USE_SYSTEM_LIBRARIES=1
-    - rvm: 2.7.3
+    - rvm: 3.0.3
+      env: AR="~> 4.2.0" SQL="~>1.3.6" NOKOGIRI_USE_SYSTEM_LIBRARIES=1
+    - rvm: 2.7.5
       env: AR="~> 5.0.0" SQL="~>1.3.6" NOKOGIRI_USE_SYSTEM_LIBRARIES=1
-    - rvm: 2.7.3
+    - rvm: 2.7.5
       env: AR=">= 5.1.0.rc2,< 5.2" SQL="~>1.3.6" NOKOGIRI_USE_SYSTEM_LIBRARIES=1
-    - rvm: 2.7.3
+    - rvm: 2.7.5
       env: AR=">= 5.2.0.rc2,< 5.3,!= 5.2.3,!=5.2.3.rc1" SQL="~>1.3.6" NOKOGIRI_USE_SYSTEM_LIBRARIES=1
 script: bundle exec rake specs:travis

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
 gem 'rake', '>= 10.0'
-gem 'activerecord', ENV['AR'] ? ENV['AR'].split(",") : [">= 4.2.7", "< 6.2.0", "!= 5.2.3", "!=5.2.3.rc1"]
-gem 'railties', ENV['AR'] ? ENV['AR'].split(",") : [">= 4.2.7", "< 6.2.0", "!= 5.2.3", "!=5.2.3.rc1"]
+gem 'activerecord', ENV['AR'] ? ENV['AR'].split(",") : [">= 4.2.7", "< 7.1.0", "!= 5.2.3", "!=5.2.3.rc1"]
+gem 'railties', ENV['AR'] ? ENV['AR'].split(",") : [">= 4.2.7", "< 7.1.0", "!= 5.2.3", "!=5.2.3.rc1"]
 
 group :dev do
   gem 'sqlite3', ENV['SQL'] ? ENV['SQL'].split(",") : ['~> 1.4']

--- a/README.markdown
+++ b/README.markdown
@@ -270,3 +270,4 @@ Contributors
  - [Hassan Mahmoud](https://github.com/HassanTC)
  - [Marco Adkins](https://github.com/marcoadkins)
  - [Mithun James](https://github.com/drtechie)
+ - [Sarah Ridge](https://github.com/smridge)

--- a/standalone_migrations.gemspec
+++ b/standalone_migrations.gemspec
@@ -60,12 +60,12 @@ Gem::Specification.new do |s|
 
   if s.respond_to? :add_runtime_dependency then
     s.add_runtime_dependency(%q<rake>.freeze, [">= 10.0"])
-    s.add_runtime_dependency(%q<activerecord>.freeze, [">= 4.2.7", "< 6.2.0", "!= 5.2.3", "!= 5.2.3.rc1"])
-    s.add_runtime_dependency(%q<railties>.freeze, [">= 4.2.7", "< 6.2.0", "!= 5.2.3", "!= 5.2.3.rc1"])
+    s.add_runtime_dependency(%q<activerecord>.freeze, [">= 4.2.7", "< 7.1.0", "!= 5.2.3", "!= 5.2.3.rc1"])
+    s.add_runtime_dependency(%q<railties>.freeze, [">= 4.2.7", "< 7.1.0", "!= 5.2.3", "!= 5.2.3.rc1"])
   else
     s.add_dependency(%q<rake>.freeze, [">= 10.0"])
-    s.add_dependency(%q<activerecord>.freeze, [">= 4.2.7", "< 6.2.0", "!= 5.2.3", "!= 5.2.3.rc1"])
-    s.add_dependency(%q<railties>.freeze, [">= 4.2.7", "< 6.2.0", "!= 5.2.3", "!= 5.2.3.rc1"])
+    s.add_dependency(%q<activerecord>.freeze, [">= 4.2.7", "< 7.1.0", "!= 5.2.3", "!= 5.2.3.rc1"])
+    s.add_dependency(%q<railties>.freeze, [">= 4.2.7", "< 7.1.0", "!= 5.2.3", "!= 5.2.3.rc1"])
   end
 end
 


### PR DESCRIPTION
Now that ActiveRecord version 7 is out, it would be great to be able to upgrade. Currently, this gem blocks updating. Separate discussion but perhaps this can be relaxed a bit. Sometimes it's good to keep the versioning more open to allow people to upgrade...then if/when things break, Issues can be opened and contributions can be made. However, I understand the importance of wanting to add specs first as mentioned [here](https://github.com/thuss/standalone-migrations/pull/166#discussion_r748579430).

This PR does the following:
- Adds ActiveRecord version 7 to specs matrix
- Adds Ruby 3.0 to specs matrix
- Updates existing ruby versions to the latest patches in the spec matrix
- Regarding the `gemspec` changes. I followed the code comments to run [this command](https://github.com/smridge/standalone-migrations/blob/31c611a7ee8bea197da75d986438d37db442bc0d/standalone_migrations.gemspec#L3) to avoid updating the `gemspec` directly. However, the generated changes that seemed to be more reflective of a release. Therefore, I mainly followed [the most recent PR](https://github.com/thuss/standalone-migrations/pull/166). Happy to remove the changes to this file but not sure if the `gemspec` changes are needed to test out all the matrix fun.
- I'm not sure the settings for this repo but I'm not able to see the `travis` builds etc. Therefore, I'm not sure what is passing or not. Happy to work through anything that breaks if I'm able to somehow see the builds.