### PR TITLE
Remove default :schema value

### DIFF
--- a/lib/standalone_migrations/configurator.rb
+++ b/lib/standalone_migrations/configurator.rb
@@ -32,17 +32,15 @@ module StandaloneMigrations
     end
 
     def initialize(options = {})
-      default_schema = ENV['SCHEMA'] || ActiveRecord::Tasks::DatabaseTasks.schema_file(ActiveRecord::Base.schema_format)
       defaults = {
         :config       => "db/config.yml",
         :migrate_dir  => "db/migrate",
         :root         => Pathname.pwd,
         :seeds        => "db/seeds.rb",
-        :schema       => default_schema
       }
       @options = load_from_file(defaults.dup) || defaults.merge(options)
 
-      ENV['SCHEMA'] = schema
+      ENV['SCHEMA'] ||= schema if schema
       Rails.application.config.root = root
       Rails.application.config.paths["config/database"] = config
       Rails.application.config.paths["db/migrate"] = migrate_dir
@@ -95,7 +93,7 @@ module StandaloneMigrations
         :migrate_dir  => (config["db"] || {})["migrate"] || defaults[:migrate_dir],
         :root         => config["root"] || defaults[:root],
         :seeds        => (config["db"] || {})["seeds"] || defaults[:seeds],
-        :schema       => (config["db"] || {})["schema"] || defaults[:schema]
+        :schema       => (config["db"] || {})["schema"]
       }
     end
 

--- a/spec/standalone_migrations/configurator_spec.rb
+++ b/spec/standalone_migrations/configurator_spec.rb
@@ -87,7 +87,6 @@ module StandaloneMigrations
     end
 
     context "default values when .standalone_configurations is missing" do
-
       let(:configurator) do
         Configurator.new
       end
@@ -103,11 +102,6 @@ module StandaloneMigrations
       it "use db/seeds.rb" do
         expect(configurator.seeds).to eq("db/seeds.rb")
       end
-
-      it "use db/schema.rb" do
-        expect(configurator.schema).to end_with("/db/schema.rb")
-      end
-
     end
 
     context "passing configurations as a parameter" do


### PR DESCRIPTION
* This does not work on Rails 7 (See https://github.com/thuss/standalone-migrations/issues/169)
* This is actually redundant in all Rails versions supported by this library.
  If `ENV['SCHEMA']` is not set, Rails has its own logic for determining the
  schema file name. By default, this will `db/schema.rb`.
* Keeps the ability to set the schema via file if not already set by env var.