### PR TITLE
Use Github Actions for CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - '2.6'
+          - '2.7'
+          - '3.0'
+          - '3.1'
+        activerecord:
+          - '5.2'
+          - '6.0'
+          - '6.1'
+          - '7.0'
+        exclude:
+          - activerecord: '5.2'
+            ruby: '3.1'
+          - activerecord: '5.2'
+            ruby: '3.0'
+          - activerecord: '7.0'
+            ruby: '2.6'
+    name: Ruby ${{ matrix.ruby }} / ActiveRecord ${{ matrix.activerecord }}
+    env:
+       AR: ~> ${{ matrix.activerecord }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: |
+          bundle exec rake

--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,2 @@
---color
+--force-color
 --profile


### PR DESCRIPTION
Recent commits have not been building on Travis:

<img width="524" alt="image" src="https://user-images.githubusercontent.com/2575714/165589396-ab4de7db-0c53-4834-bac2-9218d26ad05d.png">

Travis' support for open source is significantly limited now, so switching to Github is a good alternative.

See my build here https://github.com/mlarraz/standalone-migrations/runs/6198591168

<img width="328" alt="image" src="https://user-images.githubusercontent.com/2575714/165589657-00f84096-d19c-4e94-a018-d51b1a60dbc9.png">

This makes it clear that support for Rails 7 is broken, as documented in https://github.com/thuss/standalone-migrations/issues/167 https://github.com/thuss/standalone-migrations/issues/169 and https://github.com/thuss/standalone-migrations/issues/170.

Hoping that this will highlight the issue and lead to my fix in https://github.com/thuss/standalone-migrations/pull/171 getting merged.