### PR TITLE
Support Rails 7.1

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,6 +19,8 @@ jobs:
         activerecord:
           - '6.0'
           - '6.1'
+          - '7.0'
+          - '7.1'
     name: Ruby ${{ matrix.ruby }} / ActiveRecord ${{ matrix.activerecord }}
     env:
        AR: ~> ${{ matrix.activerecord }}

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
 gem 'rake', '>= 10.0'
-gem 'activerecord', ENV['AR'] ? ENV['AR'].split(",") : [">= 6.0.0", "< 7.1.0"]
-gem 'railties', ENV['AR'] ? ENV['AR'].split(",") : [">= 6.0.0", "< 7.1.0"]
+gem 'activerecord', ENV['AR'] ? ENV['AR'].split(",") : [">= 6.0.0", "< 7.2"]
+gem 'railties', ENV['AR'] ? ENV['AR'].split(",") : [">= 6.0.0", "< 7.2"]
 gem 'nokogiri', "~> 1.14"
 
 group :dev do

--- a/spec/standalone_migrations_spec.rb
+++ b/spec/standalone_migrations_spec.rb
@@ -18,7 +18,7 @@ describe 'Standalone migrations' do
   end
 
   def schema
-    ENV['SCHEMA'] || ActiveRecord::Tasks::DatabaseTasks.schema_file(ActiveRecord::Base.schema_format)
+    ENV['SCHEMA'] || 'db/schema.rb'
   end
 
   def run(cmd)
@@ -296,13 +296,13 @@ production:
   describe 'db:test:load' do
     it 'loads' do
       write(schema, "puts 'LOADEDDD'")
-      expect(run("rake db:test:load")).to match(/LOADEDDD/)
+      expect(run("rake db:test:load_schema")).to match(/LOADEDDD/)
     end
 
     it "fails without schema" do
       schema_path = schema
       `rm -rf #{schema_path}` if File.exist?(schema_path)
-      expect { run("rake db:test:load") }.to raise_error(/try again/)
+      expect { run("rake db:test:load_schema") }.to raise_error(/try again/)
     end
   end
 

--- a/standalone_migrations.gemspec
+++ b/standalone_migrations.gemspec
@@ -66,14 +66,13 @@ Gem::Specification.new do |s|
 
   if s.respond_to? :add_runtime_dependency then
     s.add_runtime_dependency(%q<rake>.freeze, [">= 10.0"])
-    s.add_runtime_dependency(%q<activerecord>.freeze, [">= 6.0.0", "< 7.1.0"])
-    s.add_runtime_dependency(%q<railties>.freeze, [">= 6.0.0", "< 7.1.0"])
+    s.add_runtime_dependency(%q<activerecord>.freeze, [">= 6.0.0", "< 7.2"])
+    s.add_runtime_dependency(%q<railties>.freeze, [">= 6.0.0", "< 7.2"])
     s.add_runtime_dependency(%q<nokogiri>.freeze, ["~> 1.14"])
   else
     s.add_dependency(%q<rake>.freeze, [">= 10.0"])
-    s.add_dependency(%q<activerecord>.freeze, [">= 6.0.0", "< 7.1.0"])
-    s.add_dependency(%q<railties>.freeze, [">= 6.0.0", "< 7.1.0"])
+    s.add_dependency(%q<activerecord>.freeze, [">= 6.0.0", "< 7.2"])
+    s.add_dependency(%q<railties>.freeze, [">= 6.0.0", "< 7.2"])
     s.add_dependency(%q<nokogiri>.freeze, ["~> 1.14"])
   end
 end
-


### PR DESCRIPTION
`db:test:load` was removed in https://github.com/rails/rails/pull/45870