### PR TITLE
Update supported Ruby/Rails versions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,31 +13,14 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - '2.7'
-          - '3.0'
-          - '3.1'
           - '3.2'
+          - '3.3'
+          - '3.4'
         activerecord:
-          - '6.0'
-          - '6.1'
-          - '7.0'
           - '7.1'
           - '7.2'
           - '8.0'
-        include:
-          - activerecord: '8.1'
-            ruby: '3.2'
-        exclude:
-          - activerecord: '7.2'
-            ruby: '2.7'
-          - activerecord: '7.2'
-            ruby: '3.0'
-          - activerecord: '8.0'
-            ruby: '2.7'
-          - activerecord: '8.0'
-            ruby: '3.0'
-          - activerecord: '8.0'
-            ruby: '3.1'
+          - '8.1'
 
     name: Ruby ${{ matrix.ruby }} / ActiveRecord ${{ matrix.activerecord }}
     env:

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
 gem 'rake', '>= 10.0'
-gem 'activerecord', ENV['AR'] ? ENV['AR'].split(",") : [">= 6.0.0", "< 8.2"]
-gem 'railties', ENV['AR'] ? ENV['AR'].split(",") : [">= 6.0.0", "< 8.2"]
+gem 'activerecord', ENV['AR'] ? ENV['AR'].split(",") : [">= 7.1.0", "< 8.2"]
+gem 'railties', ENV['AR'] ? ENV['AR'].split(",") : [">= 7.1.0", "< 8.2"]
 gem 'nokogiri', "~> 1.14"
 gem 'logger'
 

--- a/spec/standalone_migrations_spec.rb
+++ b/spec/standalone_migrations_spec.rb
@@ -50,11 +50,7 @@ end
   end
 
   def write_multiple_migrations
-    migration_superclass = if Rails::VERSION::MAJOR >= 5
-                             "ActiveRecord::Migration[#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}]"
-                           else
-                             "ActiveRecord::Migration"
-                           end
+    migration_superclass = "ActiveRecord::Migration[#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}]"
 
     write_rakefile %{t.migrations = "db/migrations", "db/migrations2"}
     write "db/migrate/20100509095815_create_tests.rb", <<-TXT

--- a/standalone_migrations.gemspec
+++ b/standalone_migrations.gemspec
@@ -66,14 +66,14 @@ Gem::Specification.new do |s|
 
   if s.respond_to? :add_runtime_dependency then
     s.add_runtime_dependency(%q<rake>.freeze, [">= 10.0"])
-    s.add_runtime_dependency(%q<activerecord>.freeze, [">= 6.0.0", "< 8.2"])
-    s.add_runtime_dependency(%q<railties>.freeze, [">= 6.0.0", "< 8.2"])
+    s.add_runtime_dependency(%q<activerecord>.freeze, [">= 7.1.0", "< 8.2"])
+    s.add_runtime_dependency(%q<railties>.freeze, [">= 7.1.0", "< 8.2"])
     s.add_runtime_dependency(%q<nokogiri>.freeze, ["~> 1.14"])
     s.add_runtime_dependency(%q<logger>.freeze, [">= 0"])
   else
     s.add_dependency(%q<rake>.freeze, [">= 10.0"])
-    s.add_dependency(%q<activerecord>.freeze, [">= 6.0.0", "< 8.2"])
-    s.add_dependency(%q<railties>.freeze, [">= 6.0.0", "< 8.2"])
+    s.add_dependency(%q<activerecord>.freeze, [">= 7.1.0", "< 8.2"])
+    s.add_dependency(%q<railties>.freeze, [">= 7.1.0", "< 8.2"])
     s.add_dependency(%q<nokogiri>.freeze, ["~> 1.14"])
     s.add_dependency(%q<logger>.freeze, [">= 0"])
   end


### PR DESCRIPTION
Drop support for Ruby/Rails versions that are EOL, except Rails 7.1 because it was dropped fairly recently.